### PR TITLE
Update SSB - Teknologiradar.csv

### DIFF
--- a/SSB - Teknologiradar.csv
+++ b/SSB - Teknologiradar.csv
@@ -31,3 +31,4 @@ Terraform,Ta i bruk,Utvikling - Infrastruktur,FALSE,"Infrastruktur som kode som 
 MOVEit,Ta i bruk,Utvikling - Infrastruktur,FALSE,"Overføring av filer på bakkenivå"
 Apache Spark,Ta i bruk,Utvikling - Infrastruktur,FALSE,"Teknologi for minnebasert distribuert prosessering i klynger eller prosessering på enkel noder. Koden kan skrives i flere språk. Denne teknologien er en del av DAPLA. <br>Mer info her:<a href=""https://spark.apache.org"">Apache Spark</a>"
 NuGet,Prøv ut,Utvikling - Infrastruktur,FALSE,"Verktøy for kodedeling i .NET som kan brukes i Altinn. <br>Mer info her:<a href=""https://www.nuget.org"">NuGet</a>"
+Rclone,Avvent,Datainnsamling - Lagring,FALSE,Verktøy som kan brukes til kryptere og migrere data til og fra skylagringsløsninger. <br>Mer info her:<a href=""https://rclone.org"">rclone</a>"


### PR DESCRIPTION
Rclone kan blant annet brukes til kryptere data som skal legges på DAPLA (google cloud)