### PR TITLE
Flytt opentofu til avstå

### DIFF
--- a/teknologiradar.json
+++ b/teknologiradar.json
@@ -286,7 +286,7 @@
     {
       "key": "OpenTofu",
       "title": "OpenTofu",
-      "ring": "vurder",
+      "ring": "avstå",
       "quadrant": "infrastruktur",
       "description": "Infrastruktur som kode språk. Fork av Terraform tilgjengelig under MPL-2.0 lisens.\nMer info her: https://opentofu.org/",
       "timeline": [
@@ -295,6 +295,12 @@
           "ringId": "vurder",
           "date": "2024-05-31",
           "description": "Initiell plassering"
+        },
+        {
+          "moved": -1,
+          "ringId": "avstå",
+          "date": "2024-10-28",
+          "description": "Terraform er fortsatt i mest utbredt bruk (både mtp moduler og støtteverktøy som brukes rundt iac)"
         }
       ]
     },


### PR DESCRIPTION
etter diskusjon på sist tech lead forum møte ble det besluttet å flytte opentofu da utprøvingsfase ikke har gitt noen indikasjon eller anbefalinger om at det burde tas mer i bruk

Internal Ref: [TECH-29]

[TECH-29]: https://statistics-norway.atlassian.net/browse/TECH-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ