### PR TITLE
add_trivy: added trivy to vurder

### DIFF
--- a/teknologiradar.json
+++ b/teknologiradar.json
@@ -606,6 +606,20 @@
       ]
     },
     {
+      "key": "Trivy",
+      "title": "Trivy",
+      "quadrant": "sikkerhet",
+      "description": "Trivy er en omfattende, brukervennlig og åpen kildekode-basert sårbarhetsskanner for containere, kode og skytjenesteinfrastruktur. Den er inkludert i sikkerhetsverktøyene som er integrert med NAIS, men vi kan også bruke trivy til å generere sikkerhetsrapporter for våre bakkesystemer også.",
+      "timeline": [
+        {
+          "moved": 0,
+          "ringId": "vurder",
+          "date": "2025-05-28",
+          "description": "Initiell plassering"
+        }
+      ]
+    },
+    {
       "key": "Snyk",
       "title": "Snyk",
       "quadrant": "sikkerhet",


### PR DESCRIPTION
Adding trivy to vurder. The goal is to move this to "bruk" as soon as we can recommend trivy for our on-premises systems as well. The goal is to not renew the Snyk contract (1 year remaining) and instead use trivy in addition to dependabot and sonarcloud.