### PR TITLE
Vurder Qodo, a tool to generate unit tests

### DIFF
--- a/teknologiradar.json
+++ b/teknologiradar.json
@@ -516,6 +516,20 @@
       ]
     },
     {
+      "key": "Qodo",
+      "title": "Qodo",
+      "quadrant": "devops",
+      "description": "KI-verktøy spesialert på å generere gode enhetstester, spesielt god på mocking. Gratis for vanlig enhetstestbruk. Mer info her: https://www.qodo.ai/",
+      "timeline": [
+        {
+          "moved": 0,
+          "ringId": "vurder",
+          "date": "2025-06-04",
+          "description": "Initiell plassering"
+        }
+      ]
+    },
+    {
       "key": "Maven",
       "title": "Maven",
       "quadrant": "devops",


### PR DESCRIPTION
Kashyap from the test and quality group in s703 has tested different ai tools for generating unit tests: Qodo, Baserock.ai and Copilot. Qodo is considered as the best tool and it does not cost anything for normal unit test use.

As a tech-coach I have used Qodo quite a lot when writing unit tests for python libraries, and I support his conclusion.

The PxWeb project want to use Qodo for generating unit tests. I have categorized Qodo in the "vurder" category, but maybe we should put it in the "bruk" category.