### PR TITLE
add GitHub Copilot tool

### DIFF
--- a/teknologiradar.json
+++ b/teknologiradar.json
@@ -700,6 +700,20 @@
           "description": "Initiell plassering"
         }
       ]
+    },
+    {
+      "key": "Github Copilot",
+      "title": "Github Copilot",
+      "quadrant": "devops",
+      "description": "Github Copilot er en AI-assistent for kode som er integrert i utviklerverktøy og GitHub, med støtte for kodeforslag, generering og agentiske funksjoner. Bruken skal følge ADR0035 - Retningslinjer for sikker koding og ADR0038 - Bruk av agentiske kodeverktøy i applikasjonsutvikling.",
+      "timeline": [
+        {
+          "moved": 0,
+          "ringId": "bruk",
+          "date": "2026-05-04",
+          "description": "Initiell plassering"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Dette gjøres som et tiltak for ROSen som var gjennomført for GitHub Copilot Business.

Intern referanse: https://statistics-norway.atlassian.net/wiki/spaces/DAPLA/pages/5501386753/RoS+-+Github+Copilot+Business+for+IT-utviklere